### PR TITLE
Add ping response model, tests, and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - run: uv sync --frozen
+
+      - run: uv run ruff check .
+
+      - run: uv run ruff format --check .
+
+      - run: uv run pytest

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -1,8 +1,13 @@
 from fastapi import APIRouter
+from pydantic import BaseModel
 
 router = APIRouter(prefix="/v1")
 
 
+class PingResponse(BaseModel):
+    data: str
+
+
 @router.get("/ping")
-async def ping() -> dict[str, str]:
-    return {"data": "pong"}
+async def ping() -> PingResponse:
+    return PingResponse(data="pong")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from collections.abc import AsyncIterator
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.fixture
+async def client() -> AsyncIterator[AsyncClient]:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -1,0 +1,30 @@
+from httpx import AsyncClient
+
+from app.api.v1.router import PingResponse
+
+
+async def test_ping_returns_pong(client: AsyncClient) -> None:
+    response = await client.get("/v1/ping")
+
+    assert response.status_code == 200
+    assert response.json() == {"data": "pong"}
+
+
+async def test_ping_response_matches_model(client: AsyncClient) -> None:
+    response = await client.get("/v1/ping")
+
+    parsed = PingResponse.model_validate(response.json())
+    assert parsed.data == "pong"
+
+
+async def test_openapi_schema_references_ping_response(client: AsyncClient) -> None:
+    response = await client.get("/openapi.json")
+    schema = response.json()
+
+    ping_200 = schema["paths"]["/v1/ping"]["get"]["responses"]["200"]
+    ref = ping_200["content"]["application/json"]["schema"]["$ref"]
+    assert ref == "#/components/schemas/PingResponse"
+
+    ping_schema = schema["components"]["schemas"]["PingResponse"]
+    assert ping_schema["properties"]["data"]["type"] == "string"
+    assert ping_schema["required"] == ["data"]


### PR DESCRIPTION
## Summary
- Type `/v1/ping` with a `PingResponse` Pydantic model so it shows up as a named component in the OpenAPI schema
- Add pytest suite covering the endpoint response, model round-trip, and OpenAPI `$ref`
- Add CI workflow that runs `ruff check`, `ruff format --check`, and `pytest` on every push and PR

## Test plan
- [x] `uv run pytest` passes locally (3/3)
- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] CI workflow green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)