### PR TITLE
Add POST /v1/session with get-or-create user and JWT minting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/fortymm
+JWT_SECRET=change-me-to-a-long-random-string

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -7,6 +7,7 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from app.config import settings
+from app.models import Base
 
 config = context.config
 config.set_main_option("sqlalchemy.url", settings.database_url)
@@ -14,7 +15,7 @@ config.set_main_option("sqlalchemy.url", settings.database_url)
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-target_metadata = None
+target_metadata = Base.metadata
 
 
 def run_migrations_offline() -> None:

--- a/alembic/versions/0001_create_users.py
+++ b/alembic/versions/0001_create_users.py
@@ -1,0 +1,37 @@
+"""create users
+
+Revision ID: 0001_create_users
+Revises:
+Create Date: 2026-04-20
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0001_create_users"
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("username", sa.String(length=64), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_users_username", "users", ["username"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_username", table_name="users")
+    op.drop_table("users")

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -1,13 +1,73 @@
-from fastapi import APIRouter
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import decode_token, encode_token
+from app.db import get_session
+from app.models import User
+from app.usernames import generate_username
 
 router = APIRouter(prefix="/v1")
+
+_MAX_USERNAME_ATTEMPTS = 5
 
 
 class PingResponse(BaseModel):
     data: str
 
 
+class UserPublic(BaseModel):
+    id: UUID
+    username: str
+
+
+class SessionResponse(BaseModel):
+    token: str
+    user: UserPublic
+
+
 @router.get("/ping")
 async def ping() -> PingResponse:
     return PingResponse(data="pong")
+
+
+@router.post("/session")
+async def create_session(
+    db: Annotated[AsyncSession, Depends(get_session)],
+    authorization: Annotated[str | None, Header()] = None,
+) -> SessionResponse:
+    user = await _resolve_user(db, authorization)
+    if user is None:
+        user = await _create_user(db)
+
+    return SessionResponse(
+        token=encode_token(user.id),
+        user=UserPublic(id=user.id, username=user.username),
+    )
+
+
+async def _resolve_user(db: AsyncSession, authorization: str | None) -> User | None:
+    if not authorization or not authorization.lower().startswith("bearer "):
+        return None
+    token = authorization.split(" ", 1)[1].strip()
+    user_id = decode_token(token)
+    if user_id is None:
+        return None
+    return await db.get(User, user_id)
+
+
+async def _create_user(db: AsyncSession) -> User:
+    for _ in range(_MAX_USERNAME_ATTEMPTS):
+        user = User(username=generate_username())
+        db.add(user)
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            continue
+        return user
+    raise HTTPException(status_code=500, detail="Could not allocate username")

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,27 @@
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import jwt
+
+from app.config import settings
+
+JWT_ALGORITHM = "HS256"
+
+
+def encode_token(user_id: UUID) -> str:
+    now = datetime.now(UTC)
+    payload = {
+        "sub": str(user_id),
+        "iat": now,
+        "exp": now + timedelta(seconds=settings.jwt_lifetime_seconds),
+        "jti": str(uuid4()),
+    }
+    return jwt.encode(payload, settings.jwt_secret, algorithm=JWT_ALGORITHM)
+
+
+def decode_token(token: str) -> UUID | None:
+    try:
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=[JWT_ALGORITHM])
+        return UUID(payload["sub"])
+    except (jwt.InvalidTokenError, KeyError, ValueError):
+        return None

--- a/app/config.py
+++ b/app/config.py
@@ -5,6 +5,8 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     database_url: str = "postgresql+asyncpg://postgres:postgres@db:5432/fortymm"
+    jwt_secret: str
+    jwt_lifetime_seconds: int = 60 * 60 * 24 * 30
 
 
 settings = Settings()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import DateTime, String, Uuid, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    username: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/app/usernames.py
+++ b/app/usernames.py
@@ -1,0 +1,14 @@
+import secrets
+
+from wonderwords import RandomWord
+
+_ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789"
+_SUFFIX_LEN = 4
+_rw = RandomWord()
+
+
+def generate_username() -> str:
+    adj = _rw.word(include_parts_of_speech=["adjective"]).lower()
+    noun = _rw.word(include_parts_of_speech=["noun"]).lower()
+    suffix = "".join(secrets.choice(_ALPHABET) for _ in range(_SUFFIX_LEN))
+    return f"{adj}-{noun}-{suffix}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "asyncpg>=0.30",
     "alembic>=1.13",
     "pydantic-settings>=2.6",
+    "pyjwt>=2.9",
+    "wonderwords>=2.2",
 ]
 
 [dependency-groups]
@@ -18,6 +20,7 @@ dev = [
     "pytest-asyncio>=0.24",
     "httpx>=0.27",
     "ruff>=0.7",
+    "aiosqlite>=0.20",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,44 @@
-from collections.abc import AsyncIterator
+import os
 
-import pytest
-from httpx import ASGITransport, AsyncClient
+os.environ.setdefault("JWT_SECRET", "test-secret-at-least-32-bytes-long-abcdef")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
 
-from app.main import app
+from collections.abc import AsyncIterator  # noqa: E402
+
+import pytest  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+from sqlalchemy.ext.asyncio import (  # noqa: E402
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+from app.db import get_session  # noqa: E402
+from app.main import app  # noqa: E402
+from app.models import Base  # noqa: E402
 
 
 @pytest.fixture
 async def client() -> AsyncIterator[AsyncClient]:
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-        yield c
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    TestSession = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async def override_get_session() -> AsyncIterator[AsyncSession]:
+        async with TestSession() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+        await engine.dispose()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,82 @@
+import re
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from httpx import AsyncClient
+
+from app.auth import JWT_ALGORITHM
+from app.config import settings
+
+USERNAME_RE = re.compile(r"^[a-z]+-[a-z]+-[a-z2-9]{4}$")
+
+
+async def _create(client: AsyncClient, token: str | None = None) -> dict:
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    response = await client.post("/v1/session", headers=headers)
+    assert response.status_code == 200
+    return response.json()
+
+
+async def test_no_token_creates_user(client: AsyncClient) -> None:
+    body = await _create(client)
+
+    assert USERNAME_RE.match(body["user"]["username"])
+    assert body["token"]
+    assert body["user"]["id"]
+
+
+async def test_valid_token_returns_same_user_with_new_token(client: AsyncClient) -> None:
+    first = await _create(client)
+    second = await _create(client, token=first["token"])
+
+    assert second["user"]["id"] == first["user"]["id"]
+    assert second["user"]["username"] == first["user"]["username"]
+    assert second["token"] != first["token"]
+
+
+async def test_garbage_token_creates_new_user(client: AsyncClient) -> None:
+    first = await _create(client)
+    second = await _create(client, token="not.a.real.jwt")
+
+    assert second["user"]["id"] != first["user"]["id"]
+
+
+async def test_expired_token_creates_new_user(client: AsyncClient) -> None:
+    first = await _create(client)
+
+    expired = jwt.encode(
+        {
+            "sub": first["user"]["id"],
+            "iat": datetime.now(UTC) - timedelta(days=60),
+            "exp": datetime.now(UTC) - timedelta(days=30),
+        },
+        settings.jwt_secret,
+        algorithm=JWT_ALGORITHM,
+    )
+
+    second = await _create(client, token=expired)
+    assert second["user"]["id"] != first["user"]["id"]
+
+
+async def test_token_claims_are_correct(client: AsyncClient) -> None:
+    body = await _create(client)
+
+    payload = jwt.decode(body["token"], settings.jwt_secret, algorithms=[JWT_ALGORITHM])
+    assert payload["sub"] == body["user"]["id"]
+
+    expected_exp = datetime.now(UTC) + timedelta(seconds=settings.jwt_lifetime_seconds)
+    actual_exp = datetime.fromtimestamp(payload["exp"], tz=UTC)
+    assert abs((actual_exp - expected_exp).total_seconds()) < 10
+
+
+async def test_openapi_schema_exposes_session_models(client: AsyncClient) -> None:
+    schema = (await client.get("/openapi.json")).json()
+
+    post_session = schema["paths"]["/v1/session"]["post"]
+    ref = post_session["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+    assert ref == "#/components/schemas/SessionResponse"
+
+    components = schema["components"]["schemas"]
+    assert "SessionResponse" in components
+    assert "UserPublic" in components
+    assert components["SessionResponse"]["properties"]["user"]["$ref"].endswith("UserPublic")

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
@@ -142,12 +151,15 @@ dependencies = [
     { name = "asyncpg" },
     { name = "fastapi" },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "wonderwords" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiosqlite" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -160,12 +172,15 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "pydantic-settings", specifier = ">=2.6" },
+    { name = "pyjwt", specifier = ">=2.9" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
+    { name = "wonderwords", specifier = ">=2.2" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aiosqlite", specifier = ">=0.20" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
@@ -507,6 +522,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]
@@ -872,4 +896,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wonderwords"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/23/e144fc3dfabb845dc1d94c45315d97b308cf75a664e3db3a89aeb1cb505d/wonderwords-3.0.1.tar.gz", hash = "sha256:5ee43ab6f13823a857a7c3d58c7b4db6a1350bd3aa5f914ed379ad49042a1c36", size = 73339, upload-time = "2025-10-30T17:30:44.231Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/75/855c2062d28b8e9247939f8262fb2f4ff3b12a49e4bab9fd1ba16cc5df82/wonderwords-3.0.1-py3-none-any.whl", hash = "sha256:4dd66deb6a76ca9e0b0422d1d3e111f9b910d7c16922d42de733ee8def98f8d0", size = 51658, upload-time = "2025-10-30T17:30:42.785Z" },
 ]


### PR DESCRIPTION
## Summary
- `POST /v1/session` — no token → create a new `User` with a readable random username (`adjective-noun-xxxx`); valid token → reuse the user; invalid/expired token → create a new user. Every call returns a fresh 30-day HS256 JWT (self-refreshing).
- Adds `User` model + initial alembic migration (wiring `target_metadata` for the first time).
- Usernames are unique at two layers: DB `UNIQUE` index + a 4-char base32 suffix over ~10¹² combinations, with a 5-attempt retry loop on collision.
- Test setup uses in-memory `aiosqlite` + dependency override, so the endpoint is exercised end-to-end without needing Postgres.

## Decisions
| | |
|---|---|
| Signing | HS256 + `JWT_SECRET` env var (no default — app fails to start without it) |
| Lifetime | 30 days; each call returns a new token with a fresh `jti` |
| Username | `adj-noun-xxxx` via `wonderwords` + 4-char base32 (no ambiguous chars) |

## Out of scope
Passwords, email, OAuth (client or provider), refresh-token rotation, logout/revocation, rate limiting — see the plan for rationale.

## Test plan
- [x] `uv run pytest` (9/9 pass locally, including ping + session)
- [x] `uv run ruff check .` / `ruff format --check .`
- [x] Smoke-tested live against a local Postgres: no-token → new user; valid token → same user / new JWT; garbage token → new user
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)