### PR TITLE
Add /v1/roles API with member assignment and fake permissions catalogue

### DIFF
--- a/alembic/versions/0002_create_roles.py
+++ b/alembic/versions/0002_create_roles.py
@@ -1,0 +1,71 @@
+"""create roles
+
+Revision ID: 0002_create_roles
+Revises: 0001_create_users
+Create Date: 2026-04-29
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0002_create_roles"
+down_revision: str | Sequence[str] | None = "0001_create_users"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "roles",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("slug", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=64), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_roles_slug", "roles", ["slug"], unique=True)
+
+    op.create_table(
+        "user_roles",
+        sa.Column(
+            "user_id",
+            sa.Uuid(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "role_id",
+            sa.Uuid(),
+            sa.ForeignKey("roles.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "assigned_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("user_id", "role_id"),
+    )
+    op.create_index("ix_user_roles_role_id", "user_roles", ["role_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_roles_role_id", table_name="user_roles")
+    op.drop_table("user_roles")
+    op.drop_index("ix_roles_slug", table_name="roles")
+    op.drop_table("roles")

--- a/app/api/v1/permissions.py
+++ b/app/api/v1/permissions.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from app.permissions_catalogue import PERMISSION_GROUPS
+
+router = APIRouter(prefix="/permissions")
+
+
+class PermissionItem(BaseModel):
+    code: str
+    name: str
+    description: str
+
+
+class PermissionGroup(BaseModel):
+    key: str
+    label: str
+    permissions: list[PermissionItem]
+
+
+class PermissionsResponse(BaseModel):
+    groups: list[PermissionGroup]
+
+
+_RESPONSE = PermissionsResponse.model_validate({"groups": PERMISSION_GROUPS})
+
+
+@router.get("")
+async def list_permissions() -> PermissionsResponse:
+    return _RESPONSE

--- a/app/api/v1/roles.py
+++ b/app/api/v1/roles.py
@@ -14,9 +14,12 @@ from app.auth_deps import get_current_user
 from app.db import get_session
 from app.models import Role, User, UserRole
 
+# TODO(rbac): mutating endpoints below should also check the relevant
+# permission (roles.update / roles.assign) once permissions are real.
 router = APIRouter(prefix="/roles", dependencies=[Depends(get_current_user)])
 
 _MAX_SLUG_ATTEMPTS = 25
+_MAX_DESCRIPTION = 2000
 _SLUG_NON_ALNUM = re.compile(r"[^a-z0-9]+")
 
 
@@ -32,14 +35,14 @@ class RolePublic(BaseModel):
 
 class RoleCreate(BaseModel):
     name: str = Field(min_length=1, max_length=64)
-    description: str | None = None
+    description: str | None = Field(default=None, max_length=_MAX_DESCRIPTION)
     # Accepted for forward-compat with the SPA; not persisted (fake permissions).
     permission_codes: list[str] | None = None
 
 
 class RoleUpdate(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=64)
-    description: str | None = None
+    description: str | None = Field(default=None, max_length=_MAX_DESCRIPTION)
     permission_codes: list[str] | None = None
 
 
@@ -189,6 +192,7 @@ async def add_member(
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> None:
     obj = await _get_role(db, role)
+    # FK would reject a missing user with IntegrityError; pre-check is for the 404.
     user = await db.get(User, user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")

--- a/app/api/v1/roles.py
+++ b/app/api/v1/roles.py
@@ -1,0 +1,213 @@
+import re
+from datetime import datetime
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.schemas import UserPublic
+from app.auth_deps import get_current_user
+from app.db import get_session
+from app.models import Role, User, UserRole
+
+router = APIRouter(prefix="/roles", dependencies=[Depends(get_current_user)])
+
+_MAX_SLUG_ATTEMPTS = 25
+_SLUG_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+
+class RolePublic(BaseModel):
+    id: UUID
+    slug: str
+    name: str
+    description: str | None
+    member_count: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class RoleCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=64)
+    description: str | None = None
+    # Accepted for forward-compat with the SPA; not persisted (fake permissions).
+    permission_codes: list[str] | None = None
+
+
+class RoleUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=64)
+    description: str | None = None
+    permission_codes: list[str] | None = None
+
+
+class RoleMember(BaseModel):
+    user: UserPublic
+    assigned_at: datetime
+
+
+def _slugify(name: str) -> str:
+    base = _SLUG_NON_ALNUM.sub("-", name.lower()).strip("-")
+    return base or "role"
+
+
+def _ident_filter(ident: str):
+    try:
+        return Role.id == UUID(ident)
+    except ValueError:
+        return Role.slug == ident
+
+
+async def _get_role(db: AsyncSession, ident: str) -> Role:
+    role = await db.scalar(select(Role).where(_ident_filter(ident)))
+    if role is None:
+        raise HTTPException(status_code=404, detail="Role not found")
+    return role
+
+
+async def _get_role_with_count(db: AsyncSession, ident: str) -> tuple[Role, int]:
+    stmt = (
+        select(Role, func.count(UserRole.user_id))
+        .join(UserRole, UserRole.role_id == Role.id, isouter=True)
+        .where(_ident_filter(ident))
+        .group_by(Role.id)
+    )
+    row = (await db.execute(stmt)).first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Role not found")
+    return row[0], int(row[1])
+
+
+def _to_public(role: Role, member_count: int) -> RolePublic:
+    return RolePublic(
+        id=role.id,
+        slug=role.slug,
+        name=role.name,
+        description=role.description,
+        member_count=member_count,
+        created_at=role.created_at,
+        updated_at=role.updated_at,
+    )
+
+
+@router.get("")
+async def list_roles(
+    db: Annotated[AsyncSession, Depends(get_session)],
+) -> list[RolePublic]:
+    stmt = (
+        select(Role, func.count(UserRole.user_id))
+        .join(UserRole, UserRole.role_id == Role.id, isouter=True)
+        .group_by(Role.id)
+        .order_by(Role.created_at)
+    )
+    result = await db.execute(stmt)
+    return [_to_public(role, int(count)) for role, count in result.all()]
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_role(
+    payload: RoleCreate,
+    db: Annotated[AsyncSession, Depends(get_session)],
+) -> RolePublic:
+    base = _slugify(payload.name)
+    for attempt in range(_MAX_SLUG_ATTEMPTS):
+        slug = base if attempt == 0 else f"{base}-{attempt + 1}"
+        role = Role(slug=slug, name=payload.name, description=payload.description)
+        db.add(role)
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            continue
+        await db.refresh(role)
+        return _to_public(role, 0)
+    raise HTTPException(status_code=500, detail="Could not allocate role slug")
+
+
+@router.get("/{role}")
+async def get_role(
+    role: str,
+    db: Annotated[AsyncSession, Depends(get_session)],
+) -> RolePublic:
+    obj, count = await _get_role_with_count(db, role)
+    return _to_public(obj, count)
+
+
+@router.patch("/{role}")
+async def update_role(
+    role: str,
+    payload: RoleUpdate,
+    db: Annotated[AsyncSession, Depends(get_session)],
+) -> RolePublic:
+    obj, count = await _get_role_with_count(db, role)
+    data = payload.model_dump(exclude_unset=True, exclude={"permission_codes"})
+    for field, value in data.items():
+        setattr(obj, field, value)
+    await db.commit()
+    await db.refresh(obj)
+    return _to_public(obj, count)
+
+
+@router.delete("/{role}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_role(
+    role: str,
+    db: Annotated[AsyncSession, Depends(get_session)],
+) -> None:
+    obj = await _get_role(db, role)
+    await db.delete(obj)
+    await db.commit()
+
+
+@router.get("/{role}/members")
+async def list_members(
+    role: str,
+    db: Annotated[AsyncSession, Depends(get_session)],
+) -> list[RoleMember]:
+    obj = await _get_role(db, role)
+    stmt = (
+        select(User, UserRole.assigned_at)
+        .join(UserRole, UserRole.user_id == User.id)
+        .where(UserRole.role_id == obj.id)
+        .order_by(UserRole.assigned_at)
+    )
+    result = await db.execute(stmt)
+    return [
+        RoleMember(
+            user=UserPublic(id=user.id, username=user.username),
+            assigned_at=assigned_at,
+        )
+        for user, assigned_at in result.all()
+    ]
+
+
+@router.put("/{role}/members/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def add_member(
+    role: str,
+    user_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_session)],
+) -> None:
+    obj = await _get_role(db, role)
+    user = await db.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    db.add(UserRole(user_id=user_id, role_id=obj.id))
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+
+
+@router.delete("/{role}/members/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_member(
+    role: str,
+    user_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_session)],
+) -> None:
+    obj = await _get_role(db, role)
+    membership = await db.get(UserRole, (user_id, obj.id))
+    if membership is None:
+        raise HTTPException(status_code=404, detail="Membership not found")
+    await db.delete(membership)
+    await db.commit()

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -1,28 +1,28 @@
 from typing import Annotated
-from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import decode_token, encode_token
+from app.api.v1.permissions import router as permissions_router
+from app.api.v1.roles import router as roles_router
+from app.api.v1.schemas import UserPublic
+from app.auth import encode_token
+from app.auth_deps import parse_bearer_user
 from app.db import get_session
 from app.models import User
 from app.usernames import generate_username
 
 router = APIRouter(prefix="/v1")
+router.include_router(roles_router)
+router.include_router(permissions_router)
 
 _MAX_USERNAME_ATTEMPTS = 5
 
 
 class PingResponse(BaseModel):
     data: str
-
-
-class UserPublic(BaseModel):
-    id: UUID
-    username: str
 
 
 class SessionResponse(BaseModel):
@@ -40,7 +40,7 @@ async def create_session(
     db: Annotated[AsyncSession, Depends(get_session)],
     authorization: Annotated[str | None, Header()] = None,
 ) -> SessionResponse:
-    user = await _resolve_user(db, authorization)
+    user = await parse_bearer_user(db, authorization)
     if user is None:
         user = await _create_user(db)
 
@@ -48,16 +48,6 @@ async def create_session(
         token=encode_token(user.id),
         user=UserPublic(id=user.id, username=user.username),
     )
-
-
-async def _resolve_user(db: AsyncSession, authorization: str | None) -> User | None:
-    if not authorization or not authorization.lower().startswith("bearer "):
-        return None
-    token = authorization.split(" ", 1)[1].strip()
-    user_id = decode_token(token)
-    if user_id is None:
-        return None
-    return await db.get(User, user_id)
 
 
 async def _create_user(db: AsyncSession) -> User:

--- a/app/api/v1/schemas.py
+++ b/app/api/v1/schemas.py
@@ -1,0 +1,8 @@
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class UserPublic(BaseModel):
+    id: UUID
+    username: str

--- a/app/auth_deps.py
+++ b/app/auth_deps.py
@@ -1,0 +1,32 @@
+from typing import Annotated
+
+from fastapi import Depends, Header, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import decode_token
+from app.db import get_session
+from app.models import User
+
+
+async def parse_bearer_user(db: AsyncSession, authorization: str | None) -> User | None:
+    if not authorization or not authorization.lower().startswith("bearer "):
+        return None
+    token = authorization.split(" ", 1)[1].strip()
+    user_id = decode_token(token)
+    if user_id is None:
+        return None
+    return await db.get(User, user_id)
+
+
+async def get_current_user(
+    db: Annotated[AsyncSession, Depends(get_session)],
+    authorization: Annotated[str | None, Header()] = None,
+) -> User:
+    user = await parse_bearer_user(db, authorization)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return user

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID, uuid4
 
-from sqlalchemy import DateTime, String, Uuid, func
+from sqlalchemy import DateTime, ForeignKey, String, Text, Uuid, func
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -15,5 +15,37 @@ class User(Base):
     id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
     username: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class Role(Base):
+    __tablename__ = "roles"
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    slug: Mapped[str] = mapped_column(String(64), unique=True, index=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(64), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class UserRole(Base):
+    __tablename__ = "user_roles"
+
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    role_id: Mapped[UUID] = mapped_column(
+        Uuid, ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True, index=True
+    )
+    assigned_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/app/permissions_catalogue.py
+++ b/app/permissions_catalogue.py
@@ -1,0 +1,145 @@
+"""Static permission catalogue.
+
+Permissions are not enforced or persisted — this module is a frozen list of the
+29 permission codes the admin SPA renders, transcribed verbatim from the design.
+A real `permissions` table and role↔permission assignments will replace this
+later; until then, `GET /v1/permissions` reads from here.
+"""
+
+from typing import Final
+
+
+def _g(key: str, label: str, perms: list[tuple[str, str, str]]) -> dict:
+    return {
+        "key": key,
+        "label": label,
+        "permissions": [
+            {"code": code, "name": name, "description": description}
+            for code, name, description in perms
+        ],
+    }
+
+
+PERMISSION_GROUPS: Final[list[dict]] = [
+    _g(
+        "tournaments",
+        "TOURNAMENTS",
+        [
+            ("tournaments.read", "View tournaments", "See draws, schedules, standings."),
+            (
+                "tournaments.create",
+                "Create tournaments",
+                "Spin up new events and configure formats.",
+            ),
+            (
+                "tournaments.update",
+                "Edit tournaments",
+                "Modify draws, brackets, seeding, schedule.",
+            ),
+            (
+                "tournaments.delete",
+                "Delete tournaments",
+                "Permanently remove an event and its history.",
+            ),
+            (
+                "tournaments.publish",
+                "Publish to spectator view",
+                "Make a draw publicly visible.",
+            ),
+        ],
+    ),
+    _g(
+        "matches",
+        "MATCHES",
+        [
+            ("matches.read", "View match data", "Read scores, splits, rallies."),
+            (
+                "matches.score",
+                "Score live matches",
+                "Use the scoring console during live play.",
+            ),
+            (
+                "matches.adjust",
+                "Adjust historical scores",
+                "Edit a match after it has been called.",
+            ),
+            ("matches.void", "Void / replay matches", "Discard a result and rematch."),
+        ],
+    ),
+    _g(
+        "players",
+        "PLAYERS",
+        [
+            ("players.read", "View player profiles", "See ratings, history, club."),
+            ("players.invite", "Invite players", "Send a sign-up link."),
+            ("players.merge", "Merge duplicates", "Combine two profiles into one."),
+            (
+                "players.delete",
+                "Delete players",
+                "Hard-delete a profile and all matches.",
+            ),
+        ],
+    ),
+    _g(
+        "solver",
+        "SOLVER",
+        [
+            ("solver.run", "Run the SMT solver", "Trigger schedule generation."),
+            (
+                "solver.constraints",
+                "Edit solver constraints",
+                "Add / remove / weight constraints.",
+            ),
+            (
+                "solver.override",
+                "Override solver output",
+                "Manually move a match against the solution.",
+            ),
+        ],
+    ),
+    _g(
+        "users_access",
+        "USERS & ACCESS",
+        [
+            ("users.read", "View users", "List FortyMM staff and their details."),
+            ("users.invite", "Invite users", "Send an invite to join FortyMM staff."),
+            (
+                "users.update",
+                "Edit user details",
+                "Change name, email, club, contact info.",
+            ),
+            ("users.suspend", "Suspend / reactivate", "Temporarily revoke access."),
+            ("users.delete", "Delete users", "Permanently remove a user account."),
+            (
+                "users.reset_pw",
+                "Send password resets",
+                "Trigger a reset email for any user.",
+            ),
+            ("roles.read", "View roles", "See role list and assignments."),
+            (
+                "roles.update",
+                "Edit roles",
+                "Create custom roles, change permissions.",
+            ),
+            ("roles.assign", "Assign roles to users", "Change a user's role."),
+        ],
+    ),
+    _g(
+        "reports",
+        "REPORTS & DATA",
+        [
+            (
+                "reports.read",
+                "View reports",
+                "Tournament summaries, court utilisation.",
+            ),
+            ("reports.export", "Export reports", "Download CSV / PDF."),
+            (
+                "audit.read",
+                "Read audit log",
+                "See every admin action across the platform.",
+            ),
+            ("billing.read", "View billing", "(There is none. Free forever.)"),
+        ],
+    ),
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator  # noqa: E402
 
 import pytest  # noqa: E402
 from httpx import ASGITransport, AsyncClient  # noqa: E402
+from sqlalchemy import event  # noqa: E402
 from sqlalchemy.ext.asyncio import (  # noqa: E402
     AsyncSession,
     async_sessionmaker,
@@ -26,6 +27,13 @@ async def client() -> AsyncIterator[AsyncClient]:
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_sqlite_fks(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys = ON")
+        cursor.close()
+
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
@@ -42,3 +50,12 @@ async def client() -> AsyncIterator[AsyncClient]:
     finally:
         app.dependency_overrides.pop(get_session, None)
         await engine.dispose()
+
+
+@pytest.fixture
+async def me(client: AsyncClient) -> dict:
+    response = await client.post("/v1/session")
+    assert response.status_code == 200
+    body = response.json()
+    body["headers"] = {"Authorization": f"Bearer {body['token']}"}
+    return body

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,44 @@
+from httpx import AsyncClient
+
+EXPECTED_GROUPS = {
+    "tournaments": 5,
+    "matches": 4,
+    "players": 4,
+    "solver": 3,
+    "users_access": 9,
+    "reports": 4,
+}
+
+
+async def test_permissions_returns_29_across_6_groups(client: AsyncClient) -> None:
+    response = await client.get("/v1/permissions")
+
+    assert response.status_code == 200
+    body = response.json()
+
+    groups = {g["key"]: g for g in body["groups"]}
+    assert set(groups) == set(EXPECTED_GROUPS)
+    for key, expected_count in EXPECTED_GROUPS.items():
+        assert len(groups[key]["permissions"]) == expected_count, key
+
+    total = sum(len(g["permissions"]) for g in body["groups"])
+    assert total == 29
+
+
+async def test_permissions_payload_shape(client: AsyncClient) -> None:
+    body = (await client.get("/v1/permissions")).json()
+
+    sample = body["groups"][0]["permissions"][0]
+    assert set(sample) == {"code", "name", "description"}
+    assert sample["code"]
+    assert sample["name"]
+    assert sample["description"]
+
+
+async def test_openapi_exposes_permissions_response(client: AsyncClient) -> None:
+    schema = (await client.get("/openapi.json")).json()
+
+    assert "/v1/permissions" in schema["paths"]
+    components = schema["components"]["schemas"]
+    for name in ("PermissionsResponse", "PermissionGroup", "PermissionItem"):
+        assert name in components

--- a/tests/test_role_members.py
+++ b/tests/test_role_members.py
@@ -1,0 +1,85 @@
+from httpx import AsyncClient
+
+
+async def _create_role(client: AsyncClient, headers: dict[str, str], name: str = "Crew") -> dict:
+    response = await client.post("/v1/roles", headers=headers, json={"name": name})
+    assert response.status_code == 201
+    return response.json()
+
+
+async def test_members_initially_empty(client: AsyncClient, me: dict) -> None:
+    role = await _create_role(client, me["headers"])
+
+    response = await client.get(f"/v1/roles/{role['slug']}/members", headers=me["headers"])
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_put_member_is_idempotent(client: AsyncClient, me: dict) -> None:
+    headers = me["headers"]
+    role = await _create_role(client, headers)
+    membership_url = f"/v1/roles/{role['slug']}/members/{me['user']['id']}"
+
+    first = await client.put(membership_url, headers=headers)
+    second = await client.put(membership_url, headers=headers)
+
+    assert first.status_code == 204
+    assert second.status_code == 204
+
+    listing = await client.get(f"/v1/roles/{role['slug']}/members", headers=headers)
+    body = listing.json()
+    assert len(body) == 1
+    assert body[0]["user"]["id"] == me["user"]["id"]
+    assert body[0]["user"]["username"] == me["user"]["username"]
+    assert body[0]["assigned_at"]
+
+
+async def test_member_count_reflected_in_list(client: AsyncClient, me: dict) -> None:
+    headers = me["headers"]
+    role = await _create_role(client, headers, name="With member")
+
+    await client.put(f"/v1/roles/{role['slug']}/members/{me['user']['id']}", headers=headers)
+
+    listing = (await client.get("/v1/roles", headers=headers)).json()
+    matched = next(r for r in listing if r["slug"] == role["slug"])
+    assert matched["member_count"] == 1
+
+
+async def test_delete_member_removes(client: AsyncClient, me: dict) -> None:
+    headers = me["headers"]
+    role = await _create_role(client, headers)
+    membership_url = f"/v1/roles/{role['slug']}/members/{me['user']['id']}"
+
+    await client.put(membership_url, headers=headers)
+    removed = await client.delete(membership_url, headers=headers)
+    again = await client.delete(membership_url, headers=headers)
+
+    assert removed.status_code == 204
+    assert again.status_code == 404
+
+
+async def test_put_member_unknown_user_returns_404(client: AsyncClient, me: dict) -> None:
+    role = await _create_role(client, me["headers"])
+
+    response = await client.put(
+        f"/v1/roles/{role['slug']}/members/00000000-0000-0000-0000-000000000000",
+        headers=me["headers"],
+    )
+
+    assert response.status_code == 404
+
+
+async def test_delete_role_cascades_memberships(client: AsyncClient, me: dict) -> None:
+    headers = me["headers"]
+    role = await _create_role(client, headers)
+
+    await client.put(f"/v1/roles/{role['slug']}/members/{me['user']['id']}", headers=headers)
+    await client.delete(f"/v1/roles/{role['slug']}", headers=headers)
+
+    new_role = (await client.post("/v1/roles", headers=headers, json={"name": role["name"]})).json()
+    assert new_role["slug"] == role["slug"]
+    assert new_role["member_count"] == 0
+
+    listing = (await client.get(f"/v1/roles/{new_role['slug']}/members", headers=headers)).json()
+    assert listing == []

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,148 @@
+from httpx import AsyncClient
+
+
+async def test_list_roles_empty(client: AsyncClient, me: dict) -> None:
+    response = await client.get("/v1/roles", headers=me["headers"])
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_create_role_returns_public_role(client: AsyncClient, me: dict) -> None:
+    response = await client.post(
+        "/v1/roles",
+        headers=me["headers"],
+        json={"name": "Tournament Director", "description": "Run events end-to-end."},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["name"] == "Tournament Director"
+    assert body["slug"] == "tournament-director"
+    assert body["description"] == "Run events end-to-end."
+    assert body["member_count"] == 0
+    assert body["id"]
+    assert body["created_at"]
+    assert body["updated_at"]
+
+
+async def test_create_role_collision_appends_suffix(client: AsyncClient, me: dict) -> None:
+    headers = me["headers"]
+    first = await client.post("/v1/roles", headers=headers, json={"name": "Support"})
+    second = await client.post("/v1/roles", headers=headers, json={"name": "support"})
+    third = await client.post("/v1/roles", headers=headers, json={"name": "SUPPORT!"})
+
+    assert first.json()["slug"] == "support"
+    assert second.json()["slug"] == "support-2"
+    assert third.json()["slug"] == "support-3"
+
+
+async def test_create_role_ignores_permission_codes(client: AsyncClient, me: dict) -> None:
+    response = await client.post(
+        "/v1/roles",
+        headers=me["headers"],
+        json={"name": "Umpire", "permission_codes": ["matches.score", "matches.void"]},
+    )
+
+    assert response.status_code == 201
+    assert "permission_codes" not in response.json()
+
+
+async def test_get_role_by_id_and_slug(client: AsyncClient, me: dict) -> None:
+    headers = me["headers"]
+    created = (await client.post("/v1/roles", headers=headers, json={"name": "Scorer"})).json()
+
+    by_id = await client.get(f"/v1/roles/{created['id']}", headers=headers)
+    by_slug = await client.get(f"/v1/roles/{created['slug']}", headers=headers)
+
+    assert by_id.status_code == 200
+    assert by_slug.status_code == 200
+    assert by_id.json()["id"] == by_slug.json()["id"] == created["id"]
+
+
+async def test_get_role_unknown_returns_404(client: AsyncClient, me: dict) -> None:
+    headers = me["headers"]
+    by_slug = await client.get("/v1/roles/nope", headers=headers)
+    by_uuid = await client.get("/v1/roles/00000000-0000-0000-0000-000000000000", headers=headers)
+
+    assert by_slug.status_code == 404
+    assert by_uuid.status_code == 404
+
+
+async def test_patch_role_updates_name_and_description(client: AsyncClient, me: dict) -> None:
+    headers = me["headers"]
+    created = (await client.post("/v1/roles", headers=headers, json={"name": "Old name"})).json()
+
+    response = await client.patch(
+        f"/v1/roles/{created['slug']}",
+        headers=headers,
+        json={"name": "New name", "description": "Updated."},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "New name"
+    assert body["description"] == "Updated."
+    assert body["slug"] == created["slug"]
+
+
+async def test_patch_role_accepts_and_ignores_permission_codes(
+    client: AsyncClient, me: dict
+) -> None:
+    headers = me["headers"]
+    created = (await client.post("/v1/roles", headers=headers, json={"name": "Reader"})).json()
+
+    response = await client.patch(
+        f"/v1/roles/{created['slug']}",
+        headers=headers,
+        json={"permission_codes": ["reports.read"]},
+    )
+
+    assert response.status_code == 200
+
+
+async def test_delete_role_then_get_404s(client: AsyncClient, me: dict) -> None:
+    headers = me["headers"]
+    created = (await client.post("/v1/roles", headers=headers, json={"name": "Temp"})).json()
+
+    deleted = await client.delete(f"/v1/roles/{created['slug']}", headers=headers)
+    follow_up = await client.get(f"/v1/roles/{created['slug']}", headers=headers)
+
+    assert deleted.status_code == 204
+    assert follow_up.status_code == 404
+
+
+async def test_endpoints_require_auth(client: AsyncClient) -> None:
+    no_auth: dict[str, str] = {}
+    bad_auth = {"Authorization": "Bearer not.a.real.jwt"}
+
+    cases = [
+        ("GET", "/v1/roles", None),
+        ("POST", "/v1/roles", {"name": "x"}),
+        ("GET", "/v1/roles/anything", None),
+        ("PATCH", "/v1/roles/anything", {"name": "x"}),
+        ("DELETE", "/v1/roles/anything", None),
+        ("GET", "/v1/roles/anything/members", None),
+        ("PUT", "/v1/roles/anything/members/00000000-0000-0000-0000-000000000000", None),
+        ("DELETE", "/v1/roles/anything/members/00000000-0000-0000-0000-000000000000", None),
+    ]
+    for method, path, body in cases:
+        for headers in (no_auth, bad_auth):
+            kwargs: dict = {"headers": headers}
+            if body is not None:
+                kwargs["json"] = body
+            response = await client.request(method, path, **kwargs)
+            assert response.status_code == 401, f"{method} {path} with {headers}"
+
+
+async def test_openapi_exposes_role_models(client: AsyncClient) -> None:
+    schema = (await client.get("/openapi.json")).json()
+    components = schema["components"]["schemas"]
+
+    for name in ("RolePublic", "RoleCreate", "RoleUpdate", "RoleMember"):
+        assert name in components
+
+    assert "/v1/roles" in schema["paths"]
+    assert "/v1/roles/{role}" in schema["paths"]
+    assert "/v1/roles/{role}/members" in schema["paths"]
+    assert "/v1/roles/{role}/members/{user_id}" in schema["paths"]


### PR DESCRIPTION
## Summary
- New `/v1/roles` CRUD with auto-derived slugs (UUID or slug accepted in path), plus a real `user_roles` many-to-many join with cascading FKs.
- `PUT/DELETE /v1/roles/{role}/members/{user_id}` for assignment (PUT is idempotent → 204).
- `GET /v1/permissions` returns a static, hardcoded 29-permission catalogue (6 groups). Permission codes are accepted on role create/update but **not persisted** — fake for now, as agreed.
- All `/v1/roles*` endpoints require a valid JWT via a new shared `get_current_user` dependency in `app/auth_deps.py`. The existing `/v1/session` endpoint was refactored to share the same bearer parser.
- Alembic migration `0002_create_roles` adds the `roles` table (with unique-indexed `slug`) and the `user_roles` join table (composite PK, `ON DELETE CASCADE` on both FKs, plus an `ix_user_roles_role_id` for the "list members" query path).
- Test conftest now enables `PRAGMA foreign_keys = ON` so SQLite tests actually exercise the cascade defined in the migration.

## Design notes
- **No `is_system` column / no seed.** With seeding deferred, no role can ever be flagged system through the API today, so the column would be dead weight. Easy to add later when we actually need to seed system roles.
- **`permission_codes` accepted but ignored.** Keeps the SPA's edit flow from 422-ing while we postpone real per-role permission storage. Round-trip will not survive a save — that's the trade.
- **`{role}` resolves to UUID first, falls back to slug.** The SPA uses slugs in URLs; UUIDs work too for stability.

## Test plan
- [x] `uv run pytest -q` — 29 passed
- [x] `uv run ruff check` + `uv run ruff format --check` — clean
- [x] `uv run alembic upgrade head` — migrations apply against in-memory SQLite
- [ ] Manual smoke against deployed dev: POST `/v1/session` → use token to POST/GET/PATCH/DELETE roles, PUT/DELETE `/members/{user_id}`, GET `/v1/permissions`. Verify SPA at `/admin/roles` reads the new endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)