### PR TITLE
Honor ROOT_PATH env var so /docs works behind path-prefix proxy

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://postgres:postgres@db:5432/fortymm"
     jwt_secret: str
     jwt_lifetime_seconds: int = 60 * 60 * 24 * 30
+    root_path: str = ""
 
 
 settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from app.api.v1.router import router as v1_router
+from app.config import settings
 
-app = FastAPI(title="fortymm-api")
+app = FastAPI(title="fortymm-api", root_path=settings.root_path)
 app.include_router(v1_router)


### PR DESCRIPTION
## Summary
- Adds `root_path: str = ""` to `Settings` and passes it through to `FastAPI(root_path=...)`.
- Default empty preserves local Docker dev (still hit `localhost:8000/v1/...`).
- The hosted deployment should set `ROOT_PATH=/api` so the Swagger UI HTML it serves at `/api/docs` references `/api/openapi.json` instead of `/openapi.json` (which currently falls through to the SPA's catch-all and breaks Swagger UI with `"no valid version field"`).

## Why
The deployment proxy mounts the API at `/api/` and strips the prefix before forwarding. FastAPI sees `/docs` and renders Swagger UI HTML with a hardcoded `url: '/openapi.json'`. The browser then fetches `https://fortymm.mightymoose.dev/openapi.json` (no prefix), which the SPA's wildcard route serves as `index.html`. Swagger UI tries to parse HTML as JSON and errors out.

With `ROOT_PATH=/api`:
- Spec at `/openapi.json` gains `servers: [{"url": "/api"}]`.
- `/docs` HTML embeds `url: '/api/openapi.json'`.
- Browser fetches the right URL via the proxy.

Verified locally:
```
$ ROOT_PATH=/api uv run uvicorn app.main:app --port 8766
$ curl -s :8766/openapi.json | jq .servers
[{"url": "/api"}]
$ curl -s :8766/docs | grep "url:"
url: '/api/openapi.json'
```

## After merging
Set `ROOT_PATH=/api` in the deployment env vars (alongside `JWT_SECRET`, `DATABASE_URL`).

## Test plan
- [x] `uv run pytest -q` — 29 passed (default `root_path=""`, no behavior change for existing tests)
- [x] `uv run ruff check` / `format --check` — clean
- [x] Manual: spec + docs HTML verified with `ROOT_PATH=/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)